### PR TITLE
Fix RedisGears location

### DIFF
--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -5,4 +5,4 @@ rename-command DEBUG ""
 
 # appendonly no
 loadmodule /usr/lib/redis/modules/rejson.so
-loadmodule /var/opt/redislabs/lib/modules/redisgears.so
+loadmodule /usr/lib/redis/modules/redisgears.so

--- a/redis/start_redis.sh
+++ b/redis/start_redis.sh
@@ -4,7 +4,7 @@
 # daemonize while registering necessary redis gears functions before container start.
 redis-server --daemonize yes \
              --loadmodule /usr/lib/redis/modules/redisearch.so \
-             --loadmodule /var/opt/redislabs/lib/modules/redisgears.so \
+             --loadmodule /usr/lib/redis/modules/redisgears.so \
              PythonHomeDir /opt/redislabs/lib/modules/python3 && sleep 1
 
 # todo: persist it in the image instead of calling it here:
@@ -25,5 +25,5 @@ redis-cli shutdown
 # Start server normally
 redis-server \
     --loadmodule /usr/lib/redis/modules/redisearch.so \
-    --loadmodule /var/opt/redislabs/lib/modules/redisgears.so \
+    --loadmodule /usr/lib/redis/modules/redisgears.so \
     PythonHomeDir /opt/redislabs/lib/modules/python3


### PR DESCRIPTION
### Overview
The latest `redismod` image used in this repo changes the location of RedisGears. I've updated the references of the old path to point to the new one, so that the project runs successfully.

### Testing
`docker-compose up` starts the project up successfully